### PR TITLE
Add BookingRapidAPI18Fetcher

### DIFF
--- a/tripsniper-main/src/trip_sniper/fetchers/__init__.py
+++ b/tripsniper-main/src/trip_sniper/fetchers/__init__.py
@@ -3,6 +3,12 @@
 from .booking import BookingFetcher
 from .skyscanner import SkyscannerFetcher
 from .amadeus import AmadeusFlightFetcher
+from .booking_rapidapi18 import BookingRapidAPI18Fetcher
 
-__all__ = ["BookingFetcher", "SkyscannerFetcher", "AmadeusFlightFetcher"]
+__all__ = [
+    "BookingFetcher",
+    "SkyscannerFetcher",
+    "AmadeusFlightFetcher",
+    "BookingRapidAPI18Fetcher",
+]
 

--- a/tripsniper-main/src/trip_sniper/fetchers/booking_rapidapi18.py
+++ b/tripsniper-main/src/trip_sniper/fetchers/booking_rapidapi18.py
@@ -1,0 +1,100 @@
+"""Fetcher using Booking-com18 endpoints from RapidAPI."""
+
+from __future__ import annotations
+
+import os
+from datetime import date, datetime
+from typing import List, Optional
+
+import httpx
+
+from ..models import Offer
+
+__all__ = ["BookingRapidAPI18Fetcher"]
+
+
+class BookingRapidAPI18Fetcher:
+    """Client for Booking-com18 hotel offers on RapidAPI."""
+
+    def __init__(
+        self,
+        rapidapi_key: Optional[str] = None,
+        host: Optional[str] = None,
+        http: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.rapidapi_key = rapidapi_key or os.getenv("BOOKING_RAPIDAPI_KEY")
+        self.host = host or os.getenv("BOOKING_RAPIDAPI_HOST")
+        if not self.rapidapi_key:
+            raise RuntimeError("BOOKING_RAPIDAPI_KEY not set")
+        self._http = http
+
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        key_preview = self.rapidapi_key[:4] if self.rapidapi_key else ""
+        return f"BookingRapidAPI18Fetcher(host={self.host!r}, key={key_preview}...)"
+
+    # ------------------------------------------------------------------
+    async def fetch_offers(
+        self,
+        dest_id: str,
+        checkin: date,
+        checkout: date,
+        adults: int = 2,
+        currency: Optional[str] = None,
+        limit: int = 30,
+    ) -> List[Offer]:
+        endpoint = f"https://{self.host}/v3/hotels/search"
+        params = {
+            "checkin_date": checkin,
+            "checkout_date": checkout,
+            "adults_number": adults,
+            "dest_id": dest_id,
+            "dest_type": "city",
+            "order_by": "price",
+            "room_number": 1,
+            "units": "metric",
+            "locale": "en-gb",
+            "filter_by_currency": currency
+            or os.getenv("BOOKING_RAPIDAPI_CURRENCY", "EUR"),
+            "page_number": 0,
+            "include_adjacency": "true",
+        }
+        headers = {
+            "X-RapidAPI-Key": self.rapidapi_key,
+            "X-RapidAPI-Host": self.host,
+        }
+
+        client = self._http or httpx.AsyncClient()
+        created = self._http is None
+        try:
+            resp = await client.get(endpoint, params=params, headers=headers, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+        finally:
+            if created:
+                await client.aclose()
+
+        offers: List[Offer] = []
+        for hotel in data.get("result", [])[:limit]:
+            try:
+                price_total = float(hotel.get("min_total_price", 0))
+                rating = float(hotel.get("review_score", 0))
+                stars = int(hotel.get("class", 0))
+                offer = Offer(
+                    id=f"BK18-{hotel.get('hotel_id')}",
+                    price_per_person=price_total / max(adults, 1),
+                    avg_price=price_total / max(adults, 1),
+                    hotel_rating=rating,
+                    stars=stars,
+                    distance_from_beach=0.0,
+                    direct=True,
+                    total_duration=0,
+                    date=datetime.combine(checkin, datetime.min.time()),
+                    location=dest_id,
+                    attraction_score=0.0,
+                    visible_from=datetime.utcnow(),
+                )
+                offers.append(offer)
+            except Exception:  # noqa: BLE001 - skip malformed entries
+                continue
+        return offers

--- a/tripsniper-main/tests/test_booking_rapidapi18.py
+++ b/tripsniper-main/tests/test_booking_rapidapi18.py
@@ -1,0 +1,73 @@
+from datetime import date
+import asyncio
+import pytest
+
+from trip_sniper.fetchers.booking_rapidapi18 import BookingRapidAPI18Fetcher
+from trip_sniper.models import Offer
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+        self.request_args = None
+
+    async def get(self, url, params=None, headers=None, timeout=None):
+        self.request_args = {
+            "url": url,
+            "params": params,
+            "headers": headers,
+            "timeout": timeout,
+        }
+        return DummyResponse(self.data)
+
+    async def aclose(self):
+        pass
+
+
+def test_init_env(monkeypatch):
+    monkeypatch.setenv("BOOKING_RAPIDAPI_KEY", "k1")
+    monkeypatch.setenv("BOOKING_RAPIDAPI_HOST", "host")
+    f = BookingRapidAPI18Fetcher()
+    assert f.rapidapi_key == "k1"
+    assert f.host == "host"
+
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("BOOKING_RAPIDAPI_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        BookingRapidAPI18Fetcher()
+
+
+def test_fetch_offers(monkeypatch):
+    resp = {
+        "result": [
+            {"hotel_id": "1", "min_total_price": 200, "review_score": 8.0, "class": 3}
+        ]
+    }
+    client = DummyClient(resp)
+    f = BookingRapidAPI18Fetcher("k", "example.com", http=client)
+
+    offers = asyncio.run(f.fetch_offers("dest", date(2024, 1, 1), date(2024, 1, 2)))
+
+    assert client.request_args["url"] == "https://example.com/v3/hotels/search"
+    assert client.request_args["params"]["dest_id"] == "dest"
+    assert isinstance(offers, list) and len(offers) == 1
+    offer = offers[0]
+    assert isinstance(offer, Offer)
+    assert offer.id == "BK18-1"
+    assert offer.price_per_person == 100.0
+    assert offer.hotel_rating == 8.0
+    assert offer.stars == 3
+    assert offer.location == "dest"


### PR DESCRIPTION
## Summary
- implement async BookingRapidAPI18Fetcher
- export new fetcher from fetchers package
- test new fetcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867e3d7cd40832d9afc0561e521cf56