### PR TITLE
Add test using MockTransport for booking fetcher

### DIFF
--- a/tripsniper-main/tests/test_booking_rapidapi18_fetcher.py
+++ b/tripsniper-main/tests/test_booking_rapidapi18_fetcher.py
@@ -1,0 +1,27 @@
+from datetime import date
+import asyncio
+import pytest
+import httpx
+
+from trip_sniper.fetchers.booking_rapidapi18 import BookingRapidAPI18Fetcher
+
+
+def test_fetch_offers_mock_transport():
+    fixture = {"result": [{"hotel_id": 123, "min_total_price": 200, "review_score": 8.8}]}
+
+    async def run():
+        transport = httpx.MockTransport(lambda request: httpx.Response(200, json=fixture))
+        async with httpx.AsyncClient(transport=transport) as client:
+            fetcher = BookingRapidAPI18Fetcher("test", "example.com", http=client)
+            return await fetcher.fetch_offers(
+                "dest123",
+                date(2025, 7, 15),
+                date(2025, 7, 22),
+            )
+
+    offers = asyncio.run(run())
+
+    assert len(offers) == 1
+    offer = offers[0]
+    assert offer.price_per_person == 100.0
+    assert pytest.approx(offer.hotel_rating / 10) == 0.88


### PR DESCRIPTION
## Summary
- add async test `test_booking_rapidapi18_fetcher.py` to verify `BookingRapidAPI18Fetcher`
  with a mocked HTTPX transport

## Testing
- `pytest tests/test_booking_rapidapi18_fetcher.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6867e622ca28832d940c87bcdcb7426e