### PR TITLE
Add separate env vars for flight and hotel destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ src/trip_sniper/scheduler.py starts a Celery beat process that triggers the data
 export RUN_PIPELINE_CRON="0 */6 * * *"  # run every six hours
 The pipeline reads destinations and travel dates from comma-separated environment variables:
 
-DESTINATIONS=WAW,LON
+FLIGHT_DESTS=WAW,LON          # IATA airport codes
+HOTEL_DESTS=12345,67890       # Booking.com city IDs
 DATES=2025-07-01,2025-07-08
 FLIGHTS_ONLY=0  # set to 1 to skip hotel offers

--- a/tripsniper-main/README.md
+++ b/tripsniper-main/README.md
@@ -111,7 +111,8 @@ The pipeline reads destinations and travel dates from comma-separated
 environment variables:
 
 ```ini
-DESTINATIONS=WAW,LON
+FLIGHT_DESTS=WAW,LON          # IATA airport codes
+HOTEL_DESTS=12345,67890       # Booking.com city IDs
 DATES=2025-07-01,2025-07-08
 FLIGHTS_ONLY=0  # set to 1 to skip hotel offers
 ```

--- a/tripsniper-main/tests/test_pipeline.py
+++ b/tripsniper-main/tests/test_pipeline.py
@@ -87,7 +87,7 @@ def test_run_pipeline_flights_only(monkeypatch, tmp_path):
     monkeypatch.setattr(pipeline, "BookingFetcher", DummyBookingFetcher)
     monkeypatch.setattr(pipeline, "_upsert_offer", dummy_upsert)
 
-    run_pipeline(["PAR"], ["2024-01-01"], database_url="sqlite:///ignored.db", flights_only=True)
+    run_pipeline(["PAR"], ["PAR"], ["2024-01-01"], database_url="sqlite:///ignored.db", flights_only=True)
 
     assert recorded == ["F1"]
     assert not calls["booking_init"]


### PR DESCRIPTION
## Summary
- support separate FLIGHT_DESTS and HOTEL_DESTS variables
- pair up airports and hotel city IDs when running the pipeline
- update README docs
- adjust tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68680103d66c832d9e436b810a2ff7d8