### PR TITLE
Improve error handling in fetchers

### DIFF
--- a/tripsniper-main/src/trip_sniper/fetchers/amadeus.py
+++ b/tripsniper-main/src/trip_sniper/fetchers/amadeus.py
@@ -88,7 +88,11 @@ class AmadeusFlightFetcher:
                 data = getattr(response, "data", [])
                 return self._map_offers(data, dest, date)
             except ResponseError as exc:
-                logger.warning("Amadeus request failed (attempt %s): %s", attempt + 1, exc)
+                logger.error(
+                    "Amadeus HTTP %s \u2013 %s",
+                    getattr(exc.response, "status_code", ""),
+                    getattr(exc.response, "body", ""),
+                )
                 if attempt == 2:
                     raise RuntimeError("Failed to fetch data from Amadeus API") from exc
                 time.sleep(backoff)

--- a/tripsniper-main/src/trip_sniper/fetchers/booking_rapidapi18.py
+++ b/tripsniper-main/src/trip_sniper/fetchers/booking_rapidapi18.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from typing import List, Optional
 
 import httpx
+import logging
 
 from ..models import Offer
 
@@ -70,6 +71,13 @@ class BookingRapidAPI18Fetcher:
             resp = await client.get(endpoint, params=params, headers=headers, timeout=15)
             resp.raise_for_status()
             data = resp.json()
+        except httpx.HTTPStatusError as e:
+            logging.error(
+                "Booking18 HTTP %s \u2013 %s",
+                e.response.status_code,
+                e.response.text,
+            )
+            return []
         finally:
             if created:
                 await client.aclose()


### PR DESCRIPTION
## Summary
- wrap Booking RapidAPI http call in try/except for explicit log
- log response details in Amadeus fetcher when request fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868058f8110832dab7ab929fbc7ae67